### PR TITLE
Rest Framework 2.4 requires request for serializers.HyperlinkedModelSerializer

### DIFF
--- a/edxval/serializers.py
+++ b/edxval/serializers.py
@@ -84,7 +84,7 @@ class SubtitleSerializer(serializers.ModelSerializer):
         )
 
 
-class VideoSerializer(serializers.HyperlinkedModelSerializer):
+class VideoSerializer(serializers.ModelSerializer):
     """
     Serializer for Video object
 
@@ -96,6 +96,7 @@ class VideoSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:  # pylint: disable=C0111
         model = Video
         lookup_field = "edx_video_id"
+        exclude = ('id',)
 
     def restore_fields(self, data, files):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 django>=1.4,<1.5
-djangorestframework>=2.3.14
+djangorestframework>=2.4


### PR DESCRIPTION
We could either pin the version to <2.4 or make this change to VideoSerializer. This removes the `url` field from the api response, which seemed redundant anyway.

@ormsbee 
