### PR TITLE
Expose course_id to the API

### DIFF
--- a/edxval/admin.py
+++ b/edxval/admin.py
@@ -3,9 +3,10 @@ Admin file for django app edxval.
 """
 
 from django.contrib import admin
-from .models import Video, Profile, EncodedVideo, Subtitle
+from .models import Video, Profile, EncodedVideo, Subtitle, CourseVideos
 
 admin.site.register(Video)
 admin.site.register(Profile)
 admin.site.register(EncodedVideo)
 admin.site.register(Subtitle)
+admin.site.register(CourseVideos)

--- a/edxval/api.py
+++ b/edxval/api.py
@@ -170,7 +170,7 @@ def get_video_info(edx_video_id, location=None):  # pylint: disable=W0613
         }
     """
     try:
-        video = Video.objects.get(edx_video_id=edx_video_id)
+        video = Video.objects.prefetch_related("encoded_videos", "courses").get(edx_video_id=edx_video_id)
         result = VideoSerializer(video)
     except Video.DoesNotExist:
         error_message = u"Video not found for edx_video_id: {0}".format(edx_video_id)
@@ -180,3 +180,10 @@ def get_video_info(edx_video_id, location=None):  # pylint: disable=W0613
         logger.exception(error_message)
         raise ValInternalError(error_message)
     return result.data  # pylint: disable=E1101
+
+def get_videos_for_course(course_id):
+    """
+    Returns an iterator of videos for the given course id
+    """
+    videos = Video.objects.filter(courses__course_id=course_id)
+    return (VideoSerializer(video).data for video in videos)

--- a/edxval/models.py
+++ b/edxval/models.py
@@ -79,6 +79,9 @@ class Video(models.Model):
     client_video_id = models.CharField(max_length=255, db_index=True)
     duration = models.FloatField(validators=[MinValueValidator(0)])
 
+    def get_absolute_url(self):
+        return reverse('video-detail', args=[self.edx_video_id])
+
     def __str__(self):
         return self.edx_video_id
 
@@ -91,13 +94,16 @@ class CourseVideos(models.Model):
     course_id's but each pair is unique together.
     """
     course_id = models.CharField(max_length=255)
-    video = models.ForeignKey(Video)
+    video = models.ForeignKey(Video, related_name='courses')
 
     class Meta:  # pylint: disable=C1001
         """
         course_id is listed first in this composite index
         """
         unique_together = ("course_id", "video")
+
+    def __str__(self):
+        return '%s for %s' % (self.video, self.course_id)
 
 
 class EncodedVideo(models.Model):

--- a/edxval/urls.py
+++ b/edxval/urls.py
@@ -28,4 +28,10 @@ urlpatterns = patterns(
         views.get_subtitle,
         name="subtitle-content"
     ),
+    url(
+        r'^edxval/course/(?P<course_id>[-\w/]+)$',
+        views.CourseVideoList.as_view(),
+        name="course-video-list"
+    ),
+
 )

--- a/edxval/views.py
+++ b/edxval/views.py
@@ -34,9 +34,19 @@ class VideoList(generics.ListCreateAPIView):
     GETs or POST video objects
     """
     permission_classes = (DjangoModelPermissions,)
-    queryset = Video.objects.all().prefetch_related("encoded_videos")
+    queryset = Video.objects.all().prefetch_related("encoded_videos", "courses")
     lookup_field = "edx_video_id"
     serializer_class = VideoSerializer
+
+
+class CourseVideoList(generics.ListAPIView):
+    permission_classes = (DjangoModelPermissions,)
+    queryset = Video.objects.all().prefetch_related("encoded_videos")
+    lookup_field = "course_id"
+    serializer_class = VideoSerializer
+
+    def get_queryset(self):
+        return self.queryset.filter(courses__course_id=self.kwargs['course_id'])
 
 
 class ProfileList(generics.ListCreateAPIView):


### PR DESCRIPTION
There already was a `CourseVideos` model to link videos and courses. This PR exposes course ids in the API, and allows listing videos per course with `get_videos_for_course(course_id)` and `/edxval/course/<course_id>`

@ormsbee 
