### PR TITLE
URL change: /video -> /videos, added /admin

### DIFF
--- a/edxval/api.py
+++ b/edxval/api.py
@@ -155,7 +155,7 @@ def get_video_info(edx_video_id, location=None):  # pylint: disable=W0613
         >>> get_video_info("example")
         Returns (dict):
         {
-            'url' : '/edxval/video/example',
+            'url' : '/edxval/videos/example',
             'edx_video_id': u'example',
             'duration': 111.0,
             'client_video_id': u'The example video',

--- a/edxval/settings.py
+++ b/edxval/settings.py
@@ -103,7 +103,7 @@ MIDDLEWARE_CLASSES = (
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
 
-ROOT_URLCONF = 'edxval.urls'
+ROOT_URLCONF = 'urls'
 
 # Python dotted path to the WSGI application used by Django's runserver.
 WSGI_APPLICATION = 'edxval.wsgi.application'

--- a/edxval/tests/test_views.py
+++ b/edxval/tests/test_views.py
@@ -335,7 +335,7 @@ class VideoListTest(APIAuthTestCase):
             url, constants.COMPLETE_SET_FISH, format='json'
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        video = self.client.get("/edxval/video/").data
+        video = self.client.get("/edxval/videos/").data
         self.assertEqual(len(video), 1)
         self.assertEqual(len(video[0].get("encoded_videos")), 2)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -349,7 +349,7 @@ class VideoListTest(APIAuthTestCase):
             url, constants.COMPLETE_SET_EXTRA_VIDEO_FIELD, format='json'
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        video = self.client.get("/edxval/video/").data
+        video = self.client.get("/edxval/videos/").data
         self.assertEqual(len(video), 1)
         edx_video_id = constants.VIDEO_DICT_STAR.get("edx_video_id")
         self.assertEqual(video[0].get("edx_video_id"), edx_video_id)
@@ -363,7 +363,7 @@ class VideoListTest(APIAuthTestCase):
             url, constants.VIDEO_DICT_ANIMAL, format='json'
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        video = self.client.get("/edxval/video/").data
+        video = self.client.get("/edxval/videos/").data
         self.assertEqual(len(video), 1)
         self.assertEqual(len(video[0].get("encoded_videos")), 0)
 
@@ -386,7 +386,7 @@ class VideoListTest(APIAuthTestCase):
             url, constants.VIDEO_DICT_ANIMAL, format='json'
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        videos = len(self.client.get("/edxval/video/").data)
+        videos = len(self.client.get("/edxval/videos/").data)
         self.assertEqual(videos, 1)
         response = self.client.post(
             url, constants.VIDEO_DICT_ANIMAL, format='json'
@@ -396,7 +396,7 @@ class VideoListTest(APIAuthTestCase):
             response.data.get("edx_video_id")[0],
             "Video with this Edx video id already exists."
         )
-        videos = len(self.client.get("/edxval/video/").data)
+        videos = len(self.client.get("/edxval/videos/").data)
         self.assertEqual(videos, 1)
 
     def test_post_with_youtube(self):
@@ -417,7 +417,7 @@ class VideoListTest(APIAuthTestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        videos = self.client.get("/edxval/video/").data
+        videos = self.client.get("/edxval/videos/").data
         self.assertEqual(len(videos), 1)
         self.assertIn('youtube.com', videos[0]['encoded_videos'][1]['url'])
 
@@ -430,7 +430,7 @@ class VideoListTest(APIAuthTestCase):
             url, constants.COMPLETE_SET_INVALID_ENCODED_VIDEO_FISH, format='json'
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        video = self.client.get("/edxval/video/").data
+        video = self.client.get("/edxval/videos/").data
         self.assertEqual(len(video), 0)
 
     def test_complete_set_invalid_video_post(self):
@@ -442,7 +442,7 @@ class VideoListTest(APIAuthTestCase):
             url, constants.COMPLETE_SET_INVALID_VIDEO_FISH, format='json'
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        video = self.client.get("/edxval/video/").data
+        video = self.client.get("/edxval/videos/").data
         self.assertEqual(len(video), 0)
         self.assertEqual(
             response.data.get("edx_video_id")[0],
@@ -490,7 +490,7 @@ class VideoListTest(APIAuthTestCase):
             url, video, format='json'
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        videos = self.client.get("/edxval/video/").data
+        videos = self.client.get("/edxval/videos/").data
         self.assertEqual(len(videos), 1)
         self.assertEqual(videos[0]['courses'], [course1, course2])
 
@@ -551,7 +551,7 @@ class VideoDetailTest(APIAuthTestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         response = self.client.post(url, constants.VIDEO_DICT_ZEBRA, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        videos = self.client.get("/edxval/video/").data
+        videos = self.client.get("/edxval/videos/").data
         self.assertEqual(len(videos), 2)
 
     def test_queries_for_get(self):
@@ -564,15 +564,15 @@ class VideoDetailTest(APIAuthTestCase):
         response = self.client.post(url, constants.VIDEO_DICT_ZEBRA, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         with self.assertNumQueries(7):
-            self.client.get("/edxval/video/").data
+            self.client.get("/edxval/videos/").data
         response = self.client.post(url, constants.COMPLETE_SET_FISH, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         with self.assertNumQueries(12):
-            self.client.get("/edxval/video/").data
+            self.client.get("/edxval/videos/").data
         response = self.client.post(url, constants.COMPLETE_SET_STAR, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         with self.assertNumQueries(15):
-            self.client.get("/edxval/video/").data
+            self.client.get("/edxval/videos/").data
 
 
 class SubtitleDetailTest(APIAuthTestCase):
@@ -593,7 +593,7 @@ class SubtitleDetailTest(APIAuthTestCase):
             url, constants.COMPLETE_SET_FISH, format='json'
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        video = self.client.get("/edxval/video/").data
+        video = self.client.get("/edxval/videos/").data
         self.assertEqual(len(video), 1)
         self.assertEqual(len(video[0].get("subtitles")), 2)
 

--- a/edxval/urls.py
+++ b/edxval/urls.py
@@ -10,27 +10,27 @@ from edxval import views
 urlpatterns = patterns(
     '',
     url(
-        r'^edxval/video/$',
+        r'^videos/$',
         views.VideoList.as_view(),
         name="video-list"
     ),
     url(
-        r'^edxval/video/(?P<edx_video_id>[-\w]+)$',
+        r'^videos/(?P<edx_video_id>[-\w]+)$',
         views.VideoDetail.as_view(),
         name="video-detail"
     ),
     url(
-    	r'^edxval/video/(?P<video__edx_video_id>[-\w]+)/(?P<language>[-_\w]+)$',
+        r'^videos/(?P<video__edx_video_id>[-\w]+)/(?P<language>[-_\w]+)$',
         views.SubtitleDetail.as_view(),
         name="subtitle-detail"
     ),
     url(
-    	r'^edxval/video/(?P<edx_video_id>[-\w]+)/(?P<language>[-_\w]+)/subtitle$',
+        r'^videos/(?P<edx_video_id>[-\w]+)/(?P<language>[-_\w]+)/subtitle$',
         views.get_subtitle,
         name="subtitle-content"
     ),
     url(
-        r'^edxval/course/{}$'.format(settings.COURSE_ID_PATTERN),
+        r'^courses/{}$'.format(settings.COURSE_ID_PATTERN),
         views.CourseVideoList.as_view(),
         name="course-video-list"
     ),

--- a/urls.py
+++ b/urls.py
@@ -1,17 +1,23 @@
+from django.conf import settings
 from django.conf.urls import patterns, include, url
+from django.contrib import admin
 
-from edxval import views
+admin.autodiscover()
 
 urlpatterns = patterns(
     '',
-    url(
-        r'^video/$',
-        views.VideoList.as_view(),
-        name="video_view"
-    ),
-    url(
-        r'^video/(?P<edx_video_id>\w+)',
-        views.VideoDetail.as_view(),
-        name="video_detail_view"
-    )
+    # Django Admin
+    url(r'^admin/', include(admin.site.urls)),
+
+    # edx-val
+    url(r'^edxval/', include('edxval.urls'))
 )
+
+# We need to do explicit setup of the Django debug toolbar because autodiscovery
+# causes problems when you mix debug toolbar >= 1.0 + django < 1.7, and the
+# admin uses autodiscovery. See:
+# http://django-debug-toolbar.readthedocs.org/en/1.0/installation.html#explicit-setup
+if settings.DEBUG:
+    urlpatterns += patterns('',
+        url(r'^__debug__/', include('debug_toolbar.urls')),
+    )


### PR DESCRIPTION
Changed the resource URLs to be plural for consistency with other
services in edx-platform. Added /admin for standalone running with
"manage.py runserver". Instead of using edxval.urls directly,
runserver now uses a top level urls.py that includes edxval.urls
as well as the debug toolbar and admin.
