### PR TITLE
Authorization changes to tighten permissions and use OAuth2.

### DIFF
--- a/edxval/tests/__init__.py
+++ b/edxval/tests/__init__.py
@@ -7,21 +7,21 @@ from rest_framework.test import APITestCase
 
 class APIAuthTestCase(APITestCase):
     """
-    TestCase that creates a readwrite and readonly user in setUp
+    TestCase that creates a readwrite and an unauthorized user in setUp
     """
     def setUp(self):
         self.username = self.password = 'readwrite'
         self.readwrite_user = User.objects.create_user(self.username, password=self.password)
         self.readwrite_user.user_permissions = Permission.objects.filter(content_type__app_label='edxval')
-        self.readonly_user = User.objects.create_user('readonly', 'readonly')
+        self.readonly_user = User.objects.create_user('unauthorized', password='unauthorized')
         self._login()
 
     def _logout(self):
         self.client.logout()
 
-    def _login(self, readonly=False):
-        if readonly:
-            username = password = 'readonly'
+    def _login(self, unauthorized=False):
+        if unauthorized:
+            username = password = 'unauthorized'
         else:
             username, password = self.username, self.password
-        self.client.login(username=username, password=password)
+        print self.client.login(username=username, password=password)

--- a/edxval/tests/test_views.py
+++ b/edxval/tests/test_views.py
@@ -26,21 +26,21 @@ class VideoDetail(APIAuthTestCase):
 
     def test_anonymous_denied(self):
         """
-        Tests that writing checks model permissions.
+        Tests that reading/writing is not allowed for anonymous users.
         """
         self._logout()
         url = reverse('video-list')
         response = self.client.post(url, constants.VIDEO_DICT_ANIMAL, format='json')
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_no_perms(self):
         """
-        Tests that writing checks model permissions, even for logged in users.
+        Tests that reading/writing checks model permissions for logged in users.
         """
         self._logout()
-        self._login(readonly=True)
+        self._login(unauthorized=True)
         url = reverse('video-list')
         response = self.client.post(url, constants.VIDEO_DICT_ANIMAL, format='json')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
@@ -563,15 +563,15 @@ class VideoDetailTest(APIAuthTestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         response = self.client.post(url, constants.VIDEO_DICT_ZEBRA, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(9):
             self.client.get("/edxval/videos/").data
         response = self.client.post(url, constants.COMPLETE_SET_FISH, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        with self.assertNumQueries(12):
+        with self.assertNumQueries(14):
             self.client.get("/edxval/videos/").data
         response = self.client.post(url, constants.COMPLETE_SET_STAR, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        with self.assertNumQueries(15):
+        with self.assertNumQueries(17):
             self.client.get("/edxval/videos/").data
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 django>=1.4,<1.5
 djangorestframework<2.4
 South==0.7.6
+-e git+https://github.com/edx/django-oauth2-provider.git@0.2.7-fork-edx-1#egg=django-oauth2-provider

--- a/urls.py
+++ b/urls.py
@@ -9,6 +9,9 @@ urlpatterns = patterns(
     # Django Admin
     url(r'^admin/', include(admin.site.urls)),
 
+    # Allow Django Rest Framework Auth login
+    url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
+
     # edx-val
     url(r'^edxval/', include('edxval.urls'))
 )


### PR DESCRIPTION
Heads up @davestgermain 
1. Explicitly added OAuth2 and Session as the authentication types
   allowed. Django Rest Framework allows the use of defaults via
   settings, but this may have unwanted side-effects since there are
   others using DRF with different APIs that have different requirements.
2. Created a ReadRestrictedDjangoModelPermissions class that is a
   subclass of DjangoModelPermissions. DjangoModelPermissions only cares
   about edit/update/delete permissions and makes everything world
   readable by default, which is not desirable for this API.
3. Added the DRF login URLs for running this project locally.
4. Add edX fork of django-oauth2-provider to requirements.
