### PR TITLE
build: Update team name in upgrade requirements workflow

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -13,7 +13,7 @@ jobs:
    call-upgrade-python-requirements-workflow:
     with:
        branch: ${{ github.event.inputs.branch }}
-       team_reviewers: "incident-management"
+       team_reviewers: "Incident Management"
        email_address: incident-management@edx.org
        send_success_notification: false
     secrets:


### PR DESCRIPTION
As GitHub name of Incident Management is changed so updating this in `upgrade requirements` as well.