### PR TITLE
chore: removing boto from requirements.

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,7 +2,6 @@
 
 -c constraints.txt
 
-boto
 Django
 djfernet
 django-model-utils

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-certifi==2022.12.7
+certifi==2023.5.7
     # via requests
 charset-normalizer==3.1.0
     # via requests
@@ -16,7 +16,7 @@ distlib==0.3.6
     # via virtualenv
 docopt==0.6.2
     # via coveralls
-filelock==3.11.0
+filelock==3.12.0
     # via
     #   tox
     #   virtualenv
@@ -24,13 +24,13 @@ idna==3.4
     # via requests
 packaging==23.1
     # via tox
-platformdirs==3.2.0
+platformdirs==3.5.1
     # via virtualenv
 pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-requests==2.28.2
+requests==2.31.0
     # via coveralls
 six==1.16.0
     # via tox
@@ -43,7 +43,7 @@ tox==3.28.0
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.in
-urllib3==1.26.15
+urllib3==2.0.2
     # via requests
-virtualenv==20.21.0
+virtualenv==20.23.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,23 +4,21 @@
 #
 #    make upgrade
 #
-anyio==3.6.2
+anyio==3.7.0
     # via
     #   httpcore
     #   starlette
 appdirs==1.4.4
     # via fs
-asgiref==3.6.0
+asgiref==3.7.2
     # via django
-astroid==2.15.2
+astroid==2.15.5
     # via
     #   pylint
     #   pylint-celery
 bleach==6.0.0
     # via readme-renderer
-boto==2.49.0
-    # via -r requirements/base.in
-certifi==2022.12.7
+certifi==2023.5.7
     # via
     #   httpcore
     #   httpx
@@ -56,7 +54,7 @@ coverage[toml]==6.5.0
     #   pytest-cov
 coveralls==3.3.1
     # via -r requirements/ci.in
-cryptography==40.0.1
+cryptography==41.0.1
     # via
     #   djfernet
     #   pyjwt
@@ -69,7 +67,7 @@ dill==0.3.6
     # via pylint
 distlib==0.3.6
     # via virtualenv
-django==3.2.18
+django==3.2.19
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
@@ -103,17 +101,17 @@ djfernet==0.8.1
     # via -r requirements/base.in
 docopt==0.6.2
     # via coveralls
-docutils==0.19
+docutils==0.20.1
     # via readme-renderer
 drf-jwt==1.19.2
     # via edx-drf-extensions
 edx-django-release-util==1.2.0
     # via -r requirements/base.in
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   edx-drf-extensions
     #   edx-toggles
-edx-drf-extensions==8.6.0
+edx-drf-extensions==8.8.0
     # via -r requirements/base.in
 edx-lint==5.3.4
     # via -r requirements/quality.in
@@ -122,17 +120,17 @@ edx-opaque-keys==2.3.0
 edx-toggles==5.0.0
     # via -r requirements/base.in
 exceptiongroup==1.1.1
-    # via pytest
-fastapi==0.95.1
+    # via
+    #   anyio
+    #   pytest
+fastapi==0.95.2
     # via pact-python
-filelock==3.11.0
+filelock==3.12.0
     # via
     #   tox
     #   virtualenv
 fs==2.4.16
     # via -r requirements/test.in
-future==0.18.3
-    # via pyjwkest
 h11==0.14.0
     # via
     #   httpcore
@@ -146,7 +144,7 @@ idna==3.4
     #   anyio
     #   requests
     #   rfc3986
-importlib-metadata==6.3.0
+importlib-metadata==6.6.0
     # via
     #   keyring
     #   twine
@@ -182,7 +180,7 @@ mccabe==0.7.0
     # via pylint
 mdurl==0.1.2
     # via markdown-it-py
-mock==5.0.1
+mock==5.0.2
     # via -r requirements/test.in
 more-itertools==9.1.0
     # via jaraco-classes
@@ -200,7 +198,7 @@ pillow==9.5.0
     # via -r requirements/base.in
 pkginfo==1.9.6
     # via twine
-platformdirs==3.2.0
+platformdirs==3.5.1
     # via
     #   pylint
     #   virtualenv
@@ -209,7 +207,7 @@ pluggy==1.0.0
     #   diff-cover
     #   pytest
     #   tox
-psutil==5.9.4
+psutil==5.9.5
     # via
     #   edx-django-utils
     #   pact-python
@@ -219,24 +217,20 @@ pycodestyle==2.10.0
     # via -r requirements/quality.in
 pycparser==2.21
     # via cffi
-pycryptodomex==3.17
-    # via pyjwkest
-pydantic==1.10.7
+pydantic==1.10.8
     # via fastapi
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pygments==2.15.0
+pygments==2.15.1
     # via
     #   diff-cover
     #   readme-renderer
     #   rich
-pyjwkest==1.4.2
-    # via edx-drf-extensions
-pyjwt[crypto]==2.6.0
+pyjwt[crypto]==2.7.0
     # via
     #   drf-jwt
     #   edx-drf-extensions
-pylint==2.17.2
+pylint==2.17.4
     # via
     #   edx-lint
     #   pylint-celery
@@ -246,7 +240,7 @@ pylint-celery==0.3
     # via edx-lint
 pylint-django==2.5.3
     # via edx-lint
-pylint-plugin-utils==0.7
+pylint-plugin-utils==0.8.2
     # via
     #   pylint-celery
     #   pylint-django
@@ -256,11 +250,11 @@ pynacl==1.5.0
     # via edx-django-utils
 pysrt==1.1.2
     # via -r requirements/base.in
-pytest==7.3.0
+pytest==7.3.1
     # via
     #   pytest-cov
     #   pytest-django
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements/test.in
 pytest-django==4.5.2
     # via -r requirements/test.in
@@ -279,16 +273,15 @@ pyyaml==6.0
     #   responses
 readme-renderer==37.3
     # via twine
-requests==2.28.2
+requests==2.31.0
     # via
     #   coveralls
     #   edx-drf-extensions
     #   pact-python
-    #   pyjwkest
     #   requests-toolbelt
     #   responses
     #   twine
-requests-toolbelt==0.10.1
+requests-toolbelt==1.0.0
     # via twine
 responses==0.23.1
     # via -r requirements/test.in
@@ -296,7 +289,7 @@ rfc3986[idna2008]==1.5.0
     # via
     #   httpx
     #   twine
-rich==13.3.4
+rich==13.4.1
     # via twine
 secretstorage==3.3.3
     # via keyring
@@ -310,7 +303,6 @@ six==1.16.0
     #   edx-lint
     #   fs
     #   pact-python
-    #   pyjwkest
     #   python-dateutil
     #   tox
 sniffio==1.3.0
@@ -320,11 +312,11 @@ sniffio==1.3.0
     #   httpx
 snowballstemmer==2.2.0
     # via pydocstyle
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via django
-starlette==0.26.1
+starlette==0.27.0
     # via fastapi
-stevedore==5.0.0
+stevedore==5.1.0
     # via
     #   code-annotations
     #   edx-django-utils
@@ -337,7 +329,7 @@ tomli==2.0.1
     #   pylint
     #   pytest
     #   tox
-tomlkit==0.11.7
+tomlkit==0.11.8
     # via pylint
 tox==3.28.0
     # via
@@ -348,24 +340,25 @@ tox-battery==0.6.1
     # via -r requirements/ci.in
 twine==4.0.2
     # via -r requirements/quality.in
-types-pyyaml==6.0.12.9
+types-pyyaml==6.0.12.10
     # via responses
-typing-extensions==4.5.0
+typing-extensions==4.6.3
     # via
+    #   asgiref
     #   astroid
     #   pydantic
     #   pylint
     #   rich
     #   starlette
-urllib3==1.26.15
+urllib3==2.0.2
     # via
     #   pact-python
     #   requests
     #   responses
     #   twine
-uvicorn==0.21.1
+uvicorn==0.22.0
     # via pact-python
-virtualenv==20.21.0
+virtualenv==20.23.0
     # via tox
 webencodings==0.5.1
     # via bleach

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.40.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.0.1
+pip==23.1.2
     # via -r requirements/pip.in
-setuptools==67.6.1
+setuptools==67.8.0
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,23 +4,21 @@
 #
 #    make upgrade
 #
-anyio==3.6.2
+anyio==3.7.0
     # via
     #   httpcore
     #   starlette
 appdirs==1.4.4
     # via fs
-asgiref==3.6.0
+asgiref==3.7.2
     # via django
-astroid==2.15.2
+astroid==2.15.5
     # via
     #   pylint
     #   pylint-celery
 bleach==6.0.0
     # via readme-renderer
-boto==2.49.0
-    # via -r requirements/base.in
-certifi==2022.12.7
+certifi==2023.5.7
     # via
     #   httpcore
     #   httpx
@@ -47,11 +45,11 @@ code-annotations==1.3.0
     # via
     #   edx-lint
     #   edx-toggles
-coverage[toml]==7.2.3
+coverage[toml]==7.2.7
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==40.0.1
+cryptography==41.0.1
     # via
     #   djfernet
     #   pyjwt
@@ -60,7 +58,7 @@ ddt==1.6.0
     # via -r requirements/test.in
 dill==0.3.6
     # via pylint
-django==3.2.18
+django==3.2.19
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
@@ -92,17 +90,17 @@ djangorestframework==3.14.0
     #   edx-drf-extensions
 djfernet==0.8.1
     # via -r requirements/base.in
-docutils==0.19
+docutils==0.20.1
     # via readme-renderer
 drf-jwt==1.19.2
     # via edx-drf-extensions
 edx-django-release-util==1.2.0
     # via -r requirements/base.in
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   edx-drf-extensions
     #   edx-toggles
-edx-drf-extensions==8.6.0
+edx-drf-extensions==8.8.0
     # via -r requirements/base.in
 edx-lint==5.3.4
     # via -r requirements/quality.in
@@ -111,13 +109,13 @@ edx-opaque-keys==2.3.0
 edx-toggles==5.0.0
     # via -r requirements/base.in
 exceptiongroup==1.1.1
-    # via pytest
-fastapi==0.95.1
+    # via
+    #   anyio
+    #   pytest
+fastapi==0.95.2
     # via pact-python
 fs==2.4.16
     # via -r requirements/test.in
-future==0.18.3
-    # via pyjwkest
 h11==0.14.0
     # via
     #   httpcore
@@ -131,7 +129,7 @@ idna==3.4
     #   anyio
     #   requests
     #   rfc3986
-importlib-metadata==6.3.0
+importlib-metadata==6.6.0
     # via
     #   keyring
     #   twine
@@ -165,7 +163,7 @@ mccabe==0.7.0
     # via pylint
 mdurl==0.1.2
     # via markdown-it-py
-mock==5.0.1
+mock==5.0.2
     # via -r requirements/test.in
 more-itertools==9.1.0
     # via jaraco-classes
@@ -181,11 +179,11 @@ pillow==9.5.0
     # via -r requirements/base.in
 pkginfo==1.9.6
     # via twine
-platformdirs==3.2.0
+platformdirs==3.5.1
     # via pylint
 pluggy==1.0.0
     # via pytest
-psutil==5.9.4
+psutil==5.9.5
     # via
     #   edx-django-utils
     #   pact-python
@@ -193,23 +191,19 @@ pycodestyle==2.10.0
     # via -r requirements/quality.in
 pycparser==2.21
     # via cffi
-pycryptodomex==3.17
-    # via pyjwkest
-pydantic==1.10.7
+pydantic==1.10.8
     # via fastapi
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pygments==2.15.0
+pygments==2.15.1
     # via
     #   readme-renderer
     #   rich
-pyjwkest==1.4.2
-    # via edx-drf-extensions
-pyjwt[crypto]==2.6.0
+pyjwt[crypto]==2.7.0
     # via
     #   drf-jwt
     #   edx-drf-extensions
-pylint==2.17.2
+pylint==2.17.4
     # via
     #   edx-lint
     #   pylint-celery
@@ -219,7 +213,7 @@ pylint-celery==0.3
     # via edx-lint
 pylint-django==2.5.3
     # via edx-lint
-pylint-plugin-utils==0.7
+pylint-plugin-utils==0.8.2
     # via
     #   pylint-celery
     #   pylint-django
@@ -229,11 +223,11 @@ pynacl==1.5.0
     # via edx-django-utils
 pysrt==1.1.2
     # via -r requirements/base.in
-pytest==7.3.0
+pytest==7.3.1
     # via
     #   pytest-cov
     #   pytest-django
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements/test.in
 pytest-django==4.5.2
     # via -r requirements/test.in
@@ -252,15 +246,14 @@ pyyaml==6.0
     #   responses
 readme-renderer==37.3
     # via twine
-requests==2.28.2
+requests==2.31.0
     # via
     #   edx-drf-extensions
     #   pact-python
-    #   pyjwkest
     #   requests-toolbelt
     #   responses
     #   twine
-requests-toolbelt==0.10.1
+requests-toolbelt==1.0.0
     # via twine
 responses==0.23.1
     # via -r requirements/test.in
@@ -268,7 +261,7 @@ rfc3986[idna2008]==1.5.0
     # via
     #   httpx
     #   twine
-rich==13.3.4
+rich==13.4.1
     # via twine
 secretstorage==3.3.3
     # via keyring
@@ -282,7 +275,6 @@ six==1.16.0
     #   edx-lint
     #   fs
     #   pact-python
-    #   pyjwkest
     #   python-dateutil
 sniffio==1.3.0
     # via
@@ -291,11 +283,11 @@ sniffio==1.3.0
     #   httpx
 snowballstemmer==2.2.0
     # via pydocstyle
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via django
-starlette==0.26.1
+starlette==0.27.0
     # via fastapi
-stevedore==5.0.0
+stevedore==5.1.0
     # via
     #   code-annotations
     #   edx-django-utils
@@ -307,26 +299,27 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-tomlkit==0.11.7
+tomlkit==0.11.8
     # via pylint
 twine==4.0.2
     # via -r requirements/quality.in
-types-pyyaml==6.0.12.9
+types-pyyaml==6.0.12.10
     # via responses
-typing-extensions==4.5.0
+typing-extensions==4.6.3
     # via
+    #   asgiref
     #   astroid
     #   pydantic
     #   pylint
     #   rich
     #   starlette
-urllib3==1.26.15
+urllib3==2.0.2
     # via
     #   pact-python
     #   requests
     #   responses
     #   twine
-uvicorn==0.21.1
+uvicorn==0.22.0
     # via pact-python
 webencodings==0.5.1
     # via bleach

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,17 +4,15 @@
 #
 #    make upgrade
 #
-anyio==3.6.2
+anyio==3.7.0
     # via
     #   httpcore
     #   starlette
 appdirs==1.4.4
     # via fs
-asgiref==3.6.0
+asgiref==3.7.2
     # via django
-boto==2.49.0
-    # via -r requirements/base.in
-certifi==2022.12.7
+certifi==2023.5.7
     # via
     #   httpcore
     #   httpx
@@ -35,11 +33,11 @@ click==8.1.3
     #   uvicorn
 code-annotations==1.3.0
     # via edx-toggles
-coverage[toml]==7.2.3
+coverage[toml]==7.2.7
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==40.0.1
+cryptography==41.0.1
     # via
     #   djfernet
     #   pyjwt
@@ -80,24 +78,24 @@ drf-jwt==1.19.2
     # via edx-drf-extensions
 edx-django-release-util==1.2.0
     # via -r requirements/base.in
-edx-django-utils==5.4.0
+edx-django-utils==5.5.0
     # via
     #   edx-drf-extensions
     #   edx-toggles
-edx-drf-extensions==8.6.0
+edx-drf-extensions==8.8.0
     # via -r requirements/base.in
 edx-opaque-keys==2.3.0
     # via edx-drf-extensions
 edx-toggles==5.0.0
     # via -r requirements/base.in
 exceptiongroup==1.1.1
-    # via pytest
-fastapi==0.95.1
+    # via
+    #   anyio
+    #   pytest
+fastapi==0.95.2
     # via pact-python
 fs==2.4.16
     # via -r requirements/test.in
-future==0.18.3
-    # via pyjwkest
 h11==0.14.0
     # via
     #   httpcore
@@ -119,7 +117,7 @@ lxml==4.9.2
     # via -r requirements/base.in
 markupsafe==2.1.2
     # via jinja2
-mock==5.0.1
+mock==5.0.2
     # via -r requirements/test.in
 newrelic==8.8.0
     # via edx-django-utils
@@ -133,19 +131,15 @@ pillow==9.5.0
     # via -r requirements/base.in
 pluggy==1.0.0
     # via pytest
-psutil==5.9.4
+psutil==5.9.5
     # via
     #   edx-django-utils
     #   pact-python
 pycparser==2.21
     # via cffi
-pycryptodomex==3.17
-    # via pyjwkest
-pydantic==1.10.7
+pydantic==1.10.8
     # via fastapi
-pyjwkest==1.4.2
-    # via edx-drf-extensions
-pyjwt[crypto]==2.6.0
+pyjwt[crypto]==2.7.0
     # via
     #   drf-jwt
     #   edx-drf-extensions
@@ -155,11 +149,11 @@ pynacl==1.5.0
     # via edx-django-utils
 pysrt==1.1.2
     # via -r requirements/base.in
-pytest==7.3.0
+pytest==7.3.1
     # via
     #   pytest-cov
     #   pytest-django
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via -r requirements/test.in
 pytest-django==4.5.2
     # via -r requirements/test.in
@@ -176,11 +170,10 @@ pyyaml==6.0
     #   code-annotations
     #   edx-django-release-util
     #   responses
-requests==2.28.2
+requests==2.31.0
     # via
     #   edx-drf-extensions
     #   pact-python
-    #   pyjwkest
     #   responses
 responses==0.23.1
     # via -r requirements/test.in
@@ -194,18 +187,17 @@ six==1.16.0
     #   edx-drf-extensions
     #   fs
     #   pact-python
-    #   pyjwkest
     #   python-dateutil
 sniffio==1.3.0
     # via
     #   anyio
     #   httpcore
     #   httpx
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via django
-starlette==0.26.1
+starlette==0.27.0
     # via fastapi
-stevedore==5.0.0
+stevedore==5.1.0
     # via
     #   code-annotations
     #   edx-django-utils
@@ -216,18 +208,19 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-types-pyyaml==6.0.12.9
+types-pyyaml==6.0.12.10
     # via responses
-typing-extensions==4.5.0
+typing-extensions==4.6.3
     # via
+    #   asgiref
     #   pydantic
     #   starlette
-urllib3==1.26.15
+urllib3==2.0.2
     # via
     #   pact-python
     #   requests
     #   responses
-uvicorn==0.21.1
+uvicorn==0.22.0
     # via pact-python
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
`Boto` package removed from this repo. No usage found in this repo but `boto` package available in edx-platform.