### PR TITLE
build: Switch to ubuntu-latest for builds

### DIFF
--- a/.github/workflows/check-reserved-keywords.yml
+++ b/.github/workflows/check-reserved-keywords.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   check-reserved-keywords:
     name: Check Reserved Keywords
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         python-version: ['3.8', '3.11']
         toxenv: [django42, quality]
 
@@ -46,7 +46,7 @@ jobs:
 
   provider-verification:
     name: Pact Provider Verification
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: run_tests
 
     steps:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
 
   push:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/verify_changed_contract.yml
+++ b/.github/workflows/verify_changed_contract.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   changed-contract-verification:
     name: Pact Provider Verification for a changed contract
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ commands =
     python -Wd -m pytest {posargs}
 
 [testenv:quality]
-basepython = python3.8
 allowlist_externals =
     make
 deps =


### PR DESCRIPTION
This code does not have any dependencies that are specific to any specific
version of ubuntu.  So instead of testing on a specific version and then needing
to do work to keep the versions up-to-date, we switch to the ubuntu-latest
target which should be sufficient for testing purposes.

This work is being done as a part of https://github.com/openedx/platform-roadmap/issues/377

closes https://github.com/openedx/edx-val/issues/519
