### PR TITLE
feat: remove transcript content from course-transcripts endpoint

### DIFF
--- a/edxval/api.py
+++ b/edxval/api.py
@@ -735,7 +735,7 @@ def get_videos_for_course(course_id, sort_field=None, sort_dir=SortDirection.asc
 
 def get_transcript_details_for_course(course_id):
     """
-    Gets all the transcript for a course and bundles up data.
+    Get all the transcripts for a course and return details.
 
     Args:
         course_id (String)
@@ -746,7 +746,6 @@ def get_transcript_details_for_course(course_id):
         'edx_video_id': {
             'lang_code': {
                 'provider': 'What the provider is',
-                'content': 'Content of the transcript',
                 'file_format': 'file format',
                 'url': 'location of the file',
                 'name': 'name of the file',
@@ -766,7 +765,6 @@ def get_transcript_details_for_course(course_id):
         for video_transcript in video_transcripts:
             transcript_data[video_transcript.language_code] = {
                 'provider': video_transcript.provider,
-                'content': video_transcript.transcript.file.read(),
                 'file_format': video_transcript.file_format,
                 'url': video_transcript.transcript.url,
                 'name': video_transcript.transcript.name,

--- a/edxval/tests/test_api.py
+++ b/edxval/tests/test_api.py
@@ -3159,14 +3159,12 @@ class TranscriptTest(TestCase):
         course_transcript = api.get_transcript_details_for_course(self.course_id1)
 
         self.assertEqual(course_transcript['super-soaker']['en']['provider'], TranscriptProviderType.THREE_PLAY_MEDIA)
-        self.assertIn('content', course_transcript['super-soaker']['en'])
         self.assertEqual(course_transcript['super-soaker']['en']['file_format'], utils.TranscriptFormat.SRT)
         self.assertIn('url', course_transcript['super-soaker']['en'])
         self.assertIn('name', course_transcript['super-soaker']['en'])
         self.assertIn('size', course_transcript['super-soaker']['en'])
 
         self.assertEqual(course_transcript['super-soaker']['fr']['provider'], TranscriptProviderType.CIELO24)
-        self.assertIn('content', course_transcript['super-soaker']['fr'])
         self.assertEqual(course_transcript['super-soaker']['en']['file_format'], utils.TranscriptFormat.SRT)
         self.assertIn('url', course_transcript['super-soaker']['fr'])
         self.assertIn('name', course_transcript['super-soaker']['fr'])


### PR DESCRIPTION
The API endpoint we created included transcript content with it which we no longer need. This removes that data from the call.