### PR TITLE
feat: create get_course_videos_qset API call

### DIFF
--- a/edxval/api.py
+++ b/edxval/api.py
@@ -733,6 +733,18 @@ def get_videos_for_course(course_id, sort_field=None, sort_dir=SortDirection.asc
     )
 
 
+def get_course_videos_qset(course_id):
+    """
+    Get a QuerySet of CourseVideos for a given course.
+
+    This assumes that the caller can further filter as necessary.
+    """
+    return CourseVideo.objects.select_related('video').filter(
+        course_id=str(course_id),
+        is_hidden=False,
+    )
+
+
 def get_transcript_details_for_course(course_id):
     """
     Get all the transcripts for a course and return details.

--- a/edxval/tests/test_api.py
+++ b/edxval/tests/test_api.py
@@ -761,6 +761,13 @@ class GetVideosForCourseTest(TestCase, SortedVideoTestMixin):
 
         self.assertEqual(len(course_transcript), 0)
 
+    def test_get_course_videos_qset(self):
+        """Test getting a minimal queryset."""
+        with self.assertNumQueries(1):
+            course_videos_qset = api.get_course_videos_qset(self.course_id)
+            course_video = course_videos_qset.get(video__edx_video_id="super-soaker")
+            self.assertEqual(course_video.video.client_video_id, "Shallow Swordfish")
+
 
 @ddt
 class GetYouTubeProfileVideosTest(TestCase):


### PR DESCRIPTION
This new call returns a CourseVideo queryset that will allow callers to
efficiently get what they want, instead of having to bring back a large
serialized object that may have many fields that they don't care about.
