### PR TITLE
test: Adding tests for storages.

### DIFF
--- a/edxval/tests/test_storages.py
+++ b/edxval/tests/test_storages.py
@@ -1,0 +1,99 @@
+
+"""
+Unit tests for django-storages
+"""
+
+from unittest import TestCase
+
+from django.conf import settings
+from django.test.utils import override_settings
+
+from edxval.utils import get_video_image_storage, get_video_transcript_storage
+from storages.backends.s3boto3 import S3Boto3Storage  # pylint: disable=wrong-import-order
+
+
+class S3Boto3TestCase(TestCase):
+    """Unit tests for verifying the S3Boto3 storage backend selection logic"""
+
+    def setUp(self):
+        self.storage = S3Boto3Storage()
+
+    def test_video_image_backend(self):
+        # settings file contains the `VIDEO_IMAGE_SETTINGS` but dont'have STORAGE_CLASS
+        # so it returns the default storage.
+
+        storage = get_video_image_storage()
+        storage_class = storage.__class__
+
+        self.assertEqual(
+            'django.core.files.storage.filesystem.FileSystemStorage',
+            f"{storage_class.__module__}.{storage_class.__name__}",
+        )
+
+    @override_settings(VIDEO_IMAGE_SETTINGS={
+        'STORAGE_CLASS': 'storages.backends.s3boto3.S3Boto3Storage',
+        'STORAGE_KWARGS': {
+            'bucket_name': 'test',
+            'default_acl': 'public',
+            'location': 'abc/def'
+        }
+    })
+    def test_video_image_backend_with_params(self):
+        storage = get_video_image_storage()
+        self.assertIsInstance(storage, S3Boto3Storage)
+        self.assertEqual(storage.bucket_name, "test")
+        self.assertEqual(storage.default_acl, 'public')
+        self.assertEqual(storage.location, "abc/def")
+
+    def test_video_image_without_storages_settings(self):
+        # Remove VIDEO_IMAGE_SETTINGS from settings safely
+        if hasattr(settings, 'VIDEO_IMAGE_SETTINGS'):
+            del settings.VIDEO_IMAGE_SETTINGS
+
+        storage = get_video_image_storage()
+        storage_class = storage.__class__
+
+        self.assertEqual(
+            'django.core.files.storage.filesystem.FileSystemStorage',
+            f"{storage_class.__module__}.{storage_class.__name__}",
+        )
+
+    def test_video_transcript_backend(self):
+        # settings file contains the `VIDEO_TRANSCRIPTS_SETTINGS` but dont'have STORAGE_CLASS
+        # so it returns the default storage.
+
+        storage = get_video_transcript_storage()
+        storage_class = storage.__class__
+
+        self.assertEqual(
+            'django.core.files.storage.filesystem.FileSystemStorage',
+            f"{storage_class.__module__}.{storage_class.__name__}",
+        )
+
+    @override_settings(VIDEO_TRANSCRIPTS_SETTINGS={
+        'STORAGE_CLASS': 'storages.backends.s3boto3.S3Boto3Storage',
+        'STORAGE_KWARGS': {
+            'bucket_name': 'test',
+            'default_acl': 'private',
+            'location': 'abc/'
+        }
+    })
+    def test_transcript_storage_backend_with_params(self):
+        storage = get_video_transcript_storage()
+        self.assertIsInstance(storage, S3Boto3Storage)
+        self.assertEqual(storage.bucket_name, "test")
+        self.assertEqual(storage.default_acl, 'private')
+        self.assertEqual(storage.location, 'abc/')
+
+    def test_video_transcript_without_storages_settings(self):
+        # Remove VIDEO_TRANSCRIPTS_SETTINGS from settings.
+        if hasattr(settings, 'VIDEO_TRANSCRIPTS_SETTINGS'):
+            del settings.VIDEO_TRANSCRIPTS_SETTINGS
+
+        storage = get_video_transcript_storage()
+        storage_class = storage.__class__
+
+        self.assertEqual(
+            'django.core.files.storage.filesystem.FileSystemStorage',
+            f"{storage_class.__module__}.{storage_class.__name__}",
+        )

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -2,6 +2,7 @@
 
 -c constraints.txt
 
+boto3
 coverage
 ddt
 fs

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,6 +12,12 @@ appdirs==1.4.4
     # via fs
 asgiref==3.8.1
     # via django
+boto3==1.38.8
+    # via -r requirements/test.in
+botocore==1.38.8
+    # via
+    #   boto3
+    #   s3transfer
 cachetools==5.5.2
     # via -r requirements/base.in
 certifi==2025.1.31
@@ -166,6 +172,8 @@ requests==2.32.3
     #   responses
 responses==0.25.6
     # via -r requirements/test.in
+s3transfer==0.12.0
+    # via boto3
 semantic-version==2.10.0
     # via edx-drf-extensions
 six==1.17.0


### PR DESCRIPTION
This repository currently lacks some test cases for Django storages. I'm adding a few now to ensure better coverage, especially because an upcoming PR will remove some deprecated methods from Django storages. Adding these tests in advance will help us verify the behavior and impact of the removals.


Upcoming PR https://github.com/openedx/edx-val/pull/580