### PR TITLE
fix: n+1 queries in video list and detail endpoints

### DIFF
--- a/edxval/api.py
+++ b/edxval/api.py
@@ -571,7 +571,7 @@ def _get_video(edx_video_id):
         encoded_videos = EncodedVideo.objects.select_related("profile")
         return Video.objects \
                     .prefetch_related(Prefetch("encoded_videos", queryset=encoded_videos)) \
-                    .prefetch_related("courses") \
+                    .prefetch_related("courses__video_image") \
                     .get(edx_video_id=edx_video_id)
     except Video.DoesNotExist as no_video_error:
         error_message = f"Video not found for edx_video_id: {edx_video_id}"
@@ -678,7 +678,11 @@ def _get_videos_for_filter(video_filter, sort_field=None, sort_dir=SortDirection
     the given field and direction, with ties broken by edx_video_id to ensure a
     total order.
     """
-    videos = Video.objects.filter(**video_filter)
+    encoded_videos = EncodedVideo.objects.select_related("profile")
+    videos = Video.objects.filter(**video_filter).prefetch_related(
+        Prefetch("encoded_videos", queryset=encoded_videos),
+        "courses__video_image",
+    )
     paginator_context = {}
 
     if sort_field:

--- a/edxval/tests/test_views.py
+++ b/edxval/tests/test_views.py
@@ -700,11 +700,11 @@ class VideoDetailTest(APIAuthTestCase):
             self.client.get("/edxval/videos/")
         response = self.client.post(url, constants.COMPLETE_SET_FISH, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(7):
             self.client.get("/edxval/videos/")
         response = self.client.post(url, constants.COMPLETE_SET_STAR, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(7):
             self.client.get("/edxval/videos/")
 
 

--- a/edxval/views.py
+++ b/edxval/views.py
@@ -23,6 +23,7 @@ from edxval.api import (
     update_transcript_provider,
 )
 from edxval.exceptions import InvalidTranscriptProvider, TranscriptNotFoundError
+from django.db.models import Prefetch
 from edxval.models import (
     LIST_MAX_ITEMS,
     CourseVideo,
@@ -91,12 +92,16 @@ class VideoList(generics.ListCreateAPIView):
     """
     authentication_classes = (JwtAuthentication, SessionAuthentication)
     permission_classes = (ReadRestrictedDjangoModelPermissions,)
-    queryset = Video.objects.all().prefetch_related("encoded_videos", "courses")
+    queryset = Video.objects.all()
     lookup_field = "edx_video_id"
     serializer_class = VideoSerializer
 
     def get_queryset(self):
-        qset = Video.objects.all().prefetch_related("encoded_videos", "courses")
+        encoded_videos = EncodedVideo.objects.select_related("profile")
+        qset = Video.objects.all().prefetch_related(
+            Prefetch("encoded_videos", queryset=encoded_videos),
+            "courses__video_image",
+        )
 
         args = self.request.GET
         course_id = args.get('course')


### PR DESCRIPTION
The video list and detail endpoints had n+1 query issues that scaled with the number of videos. Two culprits:

1. `EncodedVideo.profile` - each encoded video fired a separate query to fetch its profile
2. `CourseVideo.video_image` - each course-video association fired a separate query for the image

With ~50 videos in my test database, this added up to 300+ queries on a single list request.

**Fix:** added `select_related("profile")` on encoded videos and `prefetch_related("courses__video_image")` across three code paths:
- `VideoList.get_queryset()` (REST API list endpoint)
- `_get_video()` (single video lookup used throughout the codebase)
- `_get_videos_for_filter()` (filtered video queries)

Query count is now constant regardless of how many videos exist. The existing `test_queries_for_get` assertions were updated to reflect the lower counts (9 → 7, 10 → 7).

---

I populated a local SQLite database with:

- **50 videos** (`thanh-test-video-0000` to `thanh-test-video-0049`)
- **153 course-video links** (10 courses, 10-20 videos each)
- **143 encoded videos** (2-4 encoding profiles per video)
- **121 video images** (~80% of course-videos have a poster image)

Then hit `GET /edxval/videos/` and measured queries via Django Debug Toolbar.

### Before: 301 queries in 7.18ms

|Query|Count|Cause|
|---|---|---|
|Session + User|2|Normal auth|
|All videos|1|Batched correctly|
|All encoded videos|1|Batched correctly|
|All course-videos|1|Batched correctly|
|1 profile per encoded video|**143**|Missing `select_related("profile")`|
|1 video image per course-video|**153**|Missing `prefetch_related("courses__video_image")`|
|**Total**|**301**|**296 are N+1 waste**|

### After: 6 queries in 1.49ms

|Query|Count|How|
|---|---|---|
|Session + User|2|Normal auth|
|All videos|1|`SELECT * FROM video`|
|All encoded videos + profiles|1|`INNER JOIN profile` via `select_related`|
|All course-videos|1|`WHERE video_id IN (...)`|
|All video images|1|`WHERE course_video_id IN (...)`|
|**Total**|**6**|**Zero duplicates**|


Before (SQL Panel Results):
![n+1_edxval](https://github.com/user-attachments/assets/ff18675f-4323-4f23-9faa-c02c5939a0d2)

After (SQL Panel Results):
![n+1_edxval_fixed](https://github.com/user-attachments/assets/4ba6eb2f-1fc5-4134-99db-ae108dbd2ea3)
