### PR TITLE
fix: Remove end_success_notification from upgrade workflow

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -18,7 +18,6 @@ jobs:
       # user_reviewers: ""
       # team_reviewers: '2u-aurora'
       email_address: "aurora-requirements-update@2u-internal.opsgenie.net"
-      end_success_notification: true
     secrets:
       requirements_bot_github_token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}
       requirements_bot_github_email: ${{ secrets.REQUIREMENTS_BOT_GITHUB_EMAIL }}


### PR DESCRIPTION
Removed end_success_notification setting from workflow. That is not a valid parameter in the upstream file so the workflow fails.